### PR TITLE
Field where entered text to add task

### DIFF
--- a/src/ui.rs
+++ b/src/ui.rs
@@ -71,7 +71,7 @@ fn footer_view<B: Backend>(f: &mut Frame<B>, area: Rect, app: &App) {
             f.render_widget(Paragraph::new(text), area);
         }
         InputMode::AddTask => {
-            let text = format!("  {}", app.state.text_input);
+            let text = format!("  >> {}", app.state.text_input);
             f.render_widget(Paragraph::new(text), area);
         }
     }


### PR DESCRIPTION
When adding a task, a field is displayed where we can enter text, bu there is no marker that suggests that you can write something here.

I added before the field " >> " -- suggesting the user to enter something there.