### PR TITLE
fix: app crash after select on empty list

### DIFF
--- a/src/ui/stateful_ui.rs
+++ b/src/ui/stateful_ui.rs
@@ -7,12 +7,20 @@ pub struct StatefulUi {
 
 impl StatefulUi {
     pub fn next_task(&mut self, tasks_len: usize) {
+        if tasks_len == 0 {
+            return;
+        }
+
         let current = self.tasks.selected();
         let next = current.map(|i| (i + 1) % tasks_len);
         self.tasks.select(Some(next.unwrap_or(0)));
     }
 
     pub fn previous_task(&mut self, tasks_len: usize) {
+        if tasks_len == 0 {
+            return;
+        }
+
         let current = self.tasks.selected();
         let previous = current.map(|i| i.checked_sub(1).unwrap_or(tasks_len - 1));
         self.tasks.select(Some(previous.unwrap_or(0)));


### PR DESCRIPTION
As in the title, after double arrow down/up when no task are available, app crashes