### PR TITLE
feat: add custom panic hook

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,8 +1,11 @@
 use anyhow::Result;
 use crossterm::event;
 use plan_ahead::{application::App, backend::terminal::Terminal, ui::stateful_ui::StatefulUi};
+use std::panic;
 
 fn main() -> Result<()> {
+    panic::set_hook(Box::new(panic_hook));
+
     let mut terminal = Terminal::new()?;
     let mut app = App::default();
     let mut ui = StatefulUi::default();
@@ -15,4 +18,12 @@ fn main() -> Result<()> {
         handler.on_event(event::read()?, &mut app, &mut ui);
     }
     Ok(())
+}
+
+fn panic_hook(info: &panic::PanicInfo<'_>) {
+    use crossterm::{execute, terminal};
+
+    terminal::disable_raw_mode().unwrap();
+    execute!(std::io::stdout(), terminal::LeaveAlternateScreen).unwrap();
+    println!("{info}");
 }


### PR DESCRIPTION
I was frustrated that whenever there is a panic (due to integer overflow or index out of bounds), the error won't be visible on the stdout because of tui, so I made a custom panic hook to revert to the original screen before displaying an error